### PR TITLE
"Fix notebook: Replace double quotes in f-string"

### DIFF
--- a/06-Federated-learning-Experiment-with-PyTorch.ipynb
+++ b/06-Federated-learning-Experiment-with-PyTorch.ipynb
@@ -416,7 +416,7 @@
     "            print(\"Epoch: \", epoch)\n",
     "            for idx, name in enumerate(datasites):\n",
     "                metrics = fl_metrics[epoch][idx][0]\n",
-    "                print(f\"\\t {name}: Train:{metrics[0][\"mcc\"]:.3f} | Test:{metrics[1][\"mcc\"]:.3f}\")\n",
+    "                print(f\'\\t {name}: Train:{metrics[0][\"mcc\"]:.3f} | Test:{metrics[1][\"mcc\"]:.3f}\')\n",
     "        fl_model_params = avg([params for _, params in fl_metrics[epoch]])\n",
     "    return fl_metrics, fl_model_params"
    ]


### PR DESCRIPTION
Workaround to problem mentioned at: https://stackoverflow.com/questions/67540413/f-string-unmatched-in-line-with-function-call